### PR TITLE
Introduce options to allow for more customization of the generated package

### DIFF
--- a/lib/jdk-doc.sh
+++ b/lib/jdk-doc.sh
@@ -38,7 +38,7 @@ j2sdk_doc_run() {
     diskfree "$j2se_required_space"
     read_maintainer_info
     get_distribution
-    j2se_package="$j2se_vendor-java$j2se_release-doc"
+    j2se_package="$j2se_vendor-java$j2se_release-doc$package_suffix"
     j2se_name="$j2se_package"
     local target="$package_dir/$j2se_name"
     install -d -m 755 "$( dirname "$target" )"

--- a/lib/oracle-jdk.sh
+++ b/lib/oracle-jdk.sh
@@ -106,7 +106,7 @@ EOF
       fi
       oracle_jre_lib_hl="jexec"
       oracle_bin_jdk="appletviewer extcheck idlj jar jarsigner javac javadoc javah javap jcmd jconsole jdb jdeps jhat jinfo jmap jmc jps jrunscript jsadebugd jstack jstat jstatd jvisualvm native2ascii rmic schemagen serialver wsgen wsimport xjc"
-      j2se_package="$j2se_vendor-java$j2se_release-jdk"
+      j2se_package="$j2se_vendor-java$j2se_release-jdk$package_suffix"
       j2se_run
     fi
   fi

--- a/lib/oracle-jdk.sh
+++ b/lib/oracle-jdk.sh
@@ -118,13 +118,15 @@ if [ ! -e "$jvm_base$j2se_name/debian/info" ]; then
     exit 0
 fi
 
-install_alternatives $jvm_base$j2se_name/jre/bin $oracle_jre_bin_hl
-install_alternatives $jvm_base$j2se_name/jre/bin $oracle_jre_bin_jre
-if [ -n "$oracle_no_man_jre_bin_jre" ]; then
-    install_no_man_alternatives $jvm_base$j2se_name/jre/bin $oracle_no_man_jre_bin_jre
+if [ "x$without_alternatives" == "x" ]; then
+    install_alternatives $jvm_base$j2se_name/jre/bin $oracle_jre_bin_hl
+    install_alternatives $jvm_base$j2se_name/jre/bin $oracle_jre_bin_jre
+    if [ -n "$oracle_no_man_jre_bin_jre" ]; then
+        install_no_man_alternatives $jvm_base$j2se_name/jre/bin $oracle_no_man_jre_bin_jre
+    fi
+    install_no_man_alternatives $jvm_base$j2se_name/jre/lib $oracle_jre_lib_hl
+    install_alternatives $jvm_base$j2se_name/bin $oracle_bin_jdk
 fi
-install_no_man_alternatives $jvm_base$j2se_name/jre/lib $oracle_jre_lib_hl
-install_alternatives $jvm_base$j2se_name/bin $oracle_bin_jdk
 
 # No plugin for ARM architecture yet
 if [ "${DEB_BUILD_ARCH:0:3}" != "arm" ]; then
@@ -142,13 +144,15 @@ if [ ! -e "$jvm_base$j2se_name/debian/info" ]; then
     exit 0
 fi
 
-remove_alternatives $jvm_base$j2se_name/jre/bin $oracle_jre_bin_hl
-remove_alternatives $jvm_base$j2se_name/jre/bin $oracle_jre_bin_jre
-if [ -n "$oracle_no_man_jre_bin_jre" ]; then
-    remove_alternatives $jvm_base$j2se_name/jre/bin $oracle_no_man_jre_bin_jre
+if [ "x$without_alternatives" == "x" ]; then
+    remove_alternatives $jvm_base$j2se_name/jre/bin $oracle_jre_bin_hl
+    remove_alternatives $jvm_base$j2se_name/jre/bin $oracle_jre_bin_jre
+    if [ -n "$oracle_no_man_jre_bin_jre" ]; then
+        remove_alternatives $jvm_base$j2se_name/jre/bin $oracle_no_man_jre_bin_jre
+    fi
+    remove_alternatives $jvm_base$j2se_name/jre/lib $oracle_jre_lib_hl
+    remove_alternatives $jvm_base$j2se_name/bin $oracle_bin_jdk
 fi
-remove_alternatives $jvm_base$j2se_name/jre/lib $oracle_jre_lib_hl
-remove_alternatives $jvm_base$j2se_name/bin $oracle_bin_jdk
 
 # No plugin for ARM architecture yet
 if [ "${DEB_BUILD_ARCH:0:3}" != "arm" ]; then

--- a/lib/oracle-jre.sh
+++ b/lib/oracle-jre.sh
@@ -93,10 +93,12 @@ if [ ! -e "$jvm_base$j2se_name/debian/info" ]; then
     exit 0
 fi
 
-install_alternatives $jvm_base$j2se_name/bin $oracle_jre_bin_hl
-install_alternatives $jvm_base$j2se_name/bin $oracle_jre_bin_jre
-install_no_man_alternatives $jvm_base$j2se_name/bin $oracle_no_man_jre_bin_jre
-install_no_man_alternatives $jvm_base$j2se_name/lib $oracle_jre_lib_hl
+if [ "x$without_alternatives" == "x" ]; then
+    install_alternatives $jvm_base$j2se_name/bin $oracle_jre_bin_hl
+    install_alternatives $jvm_base$j2se_name/bin $oracle_jre_bin_jre
+    install_no_man_alternatives $jvm_base$j2se_name/bin $oracle_no_man_jre_bin_jre
+    install_no_man_alternatives $jvm_base$j2se_name/lib $oracle_jre_lib_hl
+fi
 
 plugin_dir="$jvm_base$j2se_name/lib/$DEB_BUILD_ARCH"
 for b in $browser_plugin_dirs;do
@@ -111,10 +113,12 @@ if [ ! -e "$jvm_base$j2se_name/debian/info" ]; then
     exit 0
 fi
 
-remove_alternatives $jvm_base$j2se_name/bin $oracle_jre_bin_hl
-remove_alternatives $jvm_base$j2se_name/bin $oracle_jre_bin_jre
-remove_alternatives $jvm_base$j2se_name/bin $oracle_no_man_jre_bin_jre
-remove_alternatives $jvm_base$j2se_name/lib $oracle_jre_lib_hl
+if [ "x$without_alternatives" == "x" ]; then
+    remove_alternatives $jvm_base$j2se_name/bin $oracle_jre_bin_hl
+    remove_alternatives $jvm_base$j2se_name/bin $oracle_jre_bin_jre
+    remove_alternatives $jvm_base$j2se_name/bin $oracle_no_man_jre_bin_jre
+    remove_alternatives $jvm_base$j2se_name/lib $oracle_jre_lib_hl
+fi
 
 plugin_dir="$jvm_base$j2se_name/lib/$DEB_BUILD_ARCH"
 for b in $browser_plugin_dirs;do

--- a/lib/oracle-jre.sh
+++ b/lib/oracle-jre.sh
@@ -81,7 +81,7 @@ EOF
       oracle_jre_bin_jre="javaws policytool"
       oracle_no_man_jre_bin_jre="ControlPanel jcontrol"
       oracle_jre_lib_hl="jexec"
-      j2se_package="$j2se_vendor-java$j2se_release-jre"
+      j2se_package="$j2se_vendor-java$j2se_release-jre$package_suffix"
       j2se_run
     fi
   fi

--- a/make-jpkg
+++ b/make-jpkg
@@ -91,6 +91,8 @@ The following options are recognized:
   --jce-policy FILE    Replace cryptography files with versions from FILE
   --without-alternatives
                        build a package that does not install alternatives
+  --package-suffix SUFFIX
+                       append a suffix to the package name and install directory
 
   --help               display this help and exit
   --version            output version information and exit
@@ -113,6 +115,8 @@ Try \`$program_name --help' for more information.
 EOF
     exit 1
 }
+
+package_suffix=""
 
 # options
 while [[ $# -gt 0 && "x$1" == x--* ]]; do
@@ -154,6 +158,10 @@ while [[ $# -gt 0 && "x$1" == x--* ]]; do
     create_cert_softlinks="true"
     elif [[ "x$1" == x--without-alternatives ]]; then
     without_alternatives="true"
+    elif [[ "x$1" == x--package-suffix ]]; then
+    [ $# -le 1 ] && missing_argument "$1"
+    shift
+    package_suffix="$1"
     else
     unrecognized_option "$1"
     fi

--- a/make-jpkg
+++ b/make-jpkg
@@ -89,6 +89,8 @@ The following options are recognized:
   --source             build a source package instead of a binary deb package
   --with-system-certs  integrate with the system's keystore
   --jce-policy FILE    Replace cryptography files with versions from FILE
+  --without-alternatives
+                       build a package that does not install alternatives
 
   --help               display this help and exit
   --version            output version information and exit
@@ -150,6 +152,8 @@ while [[ $# -gt 0 && "x$1" == x--* ]]; do
     build_source="true"
     elif [[ "x$1" == x--with-system-certs ]]; then
     create_cert_softlinks="true"
+    elif [[ "x$1" == x--without-alternatives ]]; then
+    without_alternatives="true"
     else
     unrecognized_option "$1"
     fi

--- a/make-jpkg.1
+++ b/make-jpkg.1
@@ -74,6 +74,10 @@ from the specified JCE_POLICY_FILE.
 Build a package that does not install alternatives.
 This will remove the postinst hooks that install update-alternative symlinks.
 .TP
+.B --package-suffix \fISUFFIX\fR
+Build a package that has the given suffix.
+Adds the suffix to the generated package name and the appropriate install directories.
+.TP
 .B --help
 display help text and exit
 .TP

--- a/make-jpkg.1
+++ b/make-jpkg.1
@@ -70,6 +70,10 @@ ca-certificates and ca-certificates-java packages.
 Replace cryptography files with versions
 from the specified JCE_POLICY_FILE.
 .TP
+.B --without-alternatives
+Build a package that does not install alternatives.
+This will remove the postinst hooks that install update-alternative symlinks.
+.TP
 .B --help
 display help text and exit
 .TP


### PR DESCRIPTION
Hey,

We've recently found the need to install packages that avoids using the alternatives system, and that does not conflict  with existing packages.

These patches introduces two options;
- `--without-alternatives` which skips the generation of the install_alternatives clauses in postinst.
- `--package-suffix SUFFIX` which appends the given suffix to the generated package name and install directories.
