### PR TITLE
Add --jce-policy option

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -128,6 +128,15 @@ EOF
     fi
 }
 
+extract_jce() {
+  local zip_file="$1"
+  local dest_dir="$2"
+
+  echo "Installing unlimited strength cryptography files using $zip_file"
+  for f in {US_export,local}_policy.jar; do
+    unzip -o -j -d "$dest_dir" "$zip_file" "*/$f"
+  done
+}
 
 read_maintainer_info() {
     if [ -z "$maintainer_name" ]; then

--- a/lib/javase.sh
+++ b/lib/javase.sh
@@ -293,6 +293,9 @@ j2se_run() {
     local target="$package_dir/$j2se_name"
     install -d -m 755 "$( dirname "$target" )"
     extract_bin "$archive_path" "$j2se_expected_min_size" "$target"
+    if [[ -n "$jce_archive" ]]; then
+      extract_jce "$jce_path" "$target/jre/lib/security"
+    fi
     rm -rf "$target/.systemPrefs"
     echo "9" > "$debian_dir/compat"
     j2se_readme > "$debian_dir/README.Debian"

--- a/make-jpkg
+++ b/make-jpkg
@@ -32,6 +32,7 @@ fi
 
 genchanges=""
 build_source=""
+jce_archive=""
 
 ### check for run in fakeroot
 
@@ -79,6 +80,8 @@ Supported java binary distributions currently include:
 
 The following options are recognized:
 
+  --jce-policy FILE    Replace cryptography files with unlimited strength versions
+                       from downloaded archive
   --full-name NAME     full name used in the maintainer field of the package
   --email EMAIL        email address used in the maintainer field of the package
   --changes            create a .changes file
@@ -116,6 +119,10 @@ while [[ $# -gt 0 && "x$1" == x--* ]]; do
     elif [[ "x$1" == x--help ]]; then
     print_usage
     exit 0
+    elif [[ "x$1" == x--jce-policy ]]; then
+    [ $# -le 1 ] && missing_argument "$1"
+    shift
+    jce_archive="$1"
     elif [[ "x$1" == x--full-name ]]; then
     [ $# -le 1 ] && missing_argument "$1"
     shift
@@ -162,6 +169,9 @@ archive_name="$( basename "$archive" )"
 archive_dir="$( cd "$( dirname "$archive" )" ; pwd )"
 archive_path="$archive_dir/$archive_name"
 
+jce_name="$( basename "$jce_archive" )"
+jce_dir="$( cd "$( dirname "$jce_archive" )" ; pwd )"
+jce_path="$jce_dir/$jce_name"
 
 # error handling
 


### PR DESCRIPTION
This should give users the option to add the unlimited strength
cryptography files to the install. Example:

`make-jpkg --jce-policy /tmp/jce_policy-8.zip /tmp/jdk-8u101-linux-x64.tar.gz`

This is a mirror of the patch I attached to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=833301 for easier merging. Let me know if you need anything else!
