### PR TITLE
Adding a more specific message in the error

### DIFF
--- a/make-jpkg
+++ b/make-jpkg
@@ -262,7 +262,7 @@ echo
 
 if [[ -z "$j2se_found" ]]; then
     echo "No matching packaging method was found for $archive_name."
-    echo "Please make sure you are using a tar.gz or a self-extracting archive"
+    echo "Please make sure you are using a self-extracting archive or a tar.gz with a name matching the regex jdk-([0-9]+)(u([0-9]+))?-linux-(i586|x64|amd64|arm-vfp-hflt)\.(bin|tar\.gz)"
 fi
 
 


### PR DESCRIPTION
Hi, as we spent roughly 30 minutes debugging the script to find the mathcing regex, it would be good if a more user-friendly error message would be included.
We didn't expect the name to be such a strong constraint.
thank you